### PR TITLE
Fix: show proper calling arguments in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ Usage
 -----
 
 ```erlang
+MacFunc = sha.
 OriginalPassword = <<"password">>.
 
 % Settings
 {Salt, Iterations, DerivedLength} = {<<"salt">>, 4096, 20}.
 
 % Hash the original password.
-{ok, Key} = pbkdf2:pbkdf2(OriginalPassword, Salt, Iterations, DerivedLength).
+{ok, Key} = pbkdf2:pbkdf2(MacFunc, OriginalPassword, Salt, Iterations, DerivedLength).
 
 % At this point, Key = <<"4b007901b765489abead49d926f721d065a429c1">>.
 
@@ -44,7 +45,7 @@ OriginalPassword = <<"password">>.
 EnteredPassword = getpass().
 
 % Ensure that the entered password is the same as the original.
-{ok, Key} = pbkdf2:pbkdf2(EnteredPassword, Salt, Iterations, DerivedLength).
+{ok, Key} = pbkdf2:pbkdf2(MacFunc, EnteredPassword, Salt, Iterations, DerivedLength).
 ```
 
 If you're curious what `getpass/0` would look like, here's a sample implementation:


### PR DESCRIPTION
In the README there are a couple examples of calling `pbkdf2` which are missing
the first argument, the mac function type. There are a few different ways to
call into this library but all of them require the mac function type as the
first argument.

In this patch we're updating the README to reflect the proper usage of the function.